### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Temporary devops repo
-.devops
+/.devops
 
 # Twine temporary files
 package-lock.json
@@ -103,7 +103,7 @@ instance/
 docs/_build/
 
 # PyBuilder
-.pybuilder/
+/.pybuilder/
 /target/
 
 # Jupyter Notebook
@@ -183,9 +183,3 @@ test/.DS_Store
 
 # Cython debug symbols
 cython_debug/
-
-# dbt things
-dbt/rmi_transform/dbt_packages/
-dbt/rmi_transform/logs/
-dbt/rmi_transform/target/graph.gpickle
-dbt/rmi_transform/target/partial_parse.msgpack

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,7 +105,7 @@ repos:
         args: ["--profile", "black"]
 
   - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
-    rev: v1.6.27.13
+    rev: v1.7.0.14
     hooks:
       - id: actionlint
 


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit