### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,8 @@ repos:
       - id: check-yaml
       - id: detect-private-key
       - id: end-of-file-fixer
-      - id: mixed-line-ending
-        args: ["--fix=lf"]
+      # - id: mixed-line-ending
+      #  args: ["--fix=lf"]
       - id: name-tests-test
         args: ["--pytest-test-first"]
       - id: no-commit-to-branch
@@ -76,7 +76,7 @@ repos:
         args: [ "-d", "{rules: {line-length: {max: 120}}, ignore-from-file: [.gitignore],}", ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.0
+    rev: v0.5.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --config=ruff.toml]


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit